### PR TITLE
Bugfix

### DIFF
--- a/Nidhogg/AntiAnalysis.cpp
+++ b/Nidhogg/AntiAnalysis.cpp
@@ -676,6 +676,7 @@ NTSTATUS AntiAnalysis::MatchCallback(PVOID callack, CHAR driverName[MAX_DRIVER_P
 		}
 	}
 
+	FreeVirtualMemory(info);
 	return status;
 }
 

--- a/Nidhogg/MemoryHelper.cpp
+++ b/Nidhogg/MemoryHelper.cpp
@@ -75,7 +75,7 @@ PVOID FindPattern(PCUCHAR pattern, UCHAR wildcard, ULONG_PTR len, const PVOID ba
 * Returns:
 * There is no return value.
 */
-void FreeVirtualMemory(_In_ PVOID address) {
+void FreeVirtualMemory(_Inout_ PVOID& address) {
 	if (!address)
 		return;
 	ExFreePoolWithTag(address, DRIVER_TAG);


### PR DESCRIPTION
- Fixed memory leak in MatchCallback and FindAlertableThread functions
- Changed FreeVirtualMemory's argument to be pass-by-reference so it could really null the pointer.